### PR TITLE
packer future for projects with multiple master branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ dmypy.json
 .pyre/
 
 # End of https://www.gitignore.io/api/python
+
+# vscode
+.vscode

--- a/adcm_client/packer/bundle_build.py
+++ b/adcm_client/packer/bundle_build.py
@@ -45,7 +45,7 @@ def _pack(reponame, repopaths, tarpath, spec: SpecFile, **kwargs):
         tar_except = edition.get('exclude', [])
 
         # naming rules
-        tarname = add_build_id(repopath, reponame, name, kwargs['master_brances'])
+        tarname = add_build_id(repopath, reponame, name, kwargs['master_branches'])
 
         stream = BytesIO()
         tar = tarfile.open(fileobj=stream, mode='w|gz')

--- a/adcm_client/packer/bundle_build.py
+++ b/adcm_client/packer/bundle_build.py
@@ -37,7 +37,7 @@ def _prepare_result_dir(workspace, tarball_path):
     return tarpath
 
 
-def _pack(reponame, repopaths, tarpath, spec: SpecFile):
+def _pack(reponame, repopaths, tarpath, spec: SpecFile, **kwargs):
     tarballs = {}
     for edition in spec.data['editions']:
         name = edition.get('name')
@@ -45,7 +45,7 @@ def _pack(reponame, repopaths, tarpath, spec: SpecFile):
         tar_except = edition.get('exclude', [])
 
         # naming rules
-        tarname = add_build_id(repopath, reponame, name)
+        tarname = add_build_id(repopath, reponame, name, kwargs['master_brances'])
 
         stream = BytesIO()
         tar = tarfile.open(fileobj=stream, mode='w|gz')
@@ -65,7 +65,9 @@ def _clean_ws(path):
     remove_tree(path)
 
 
-def build(reponame, repopath, workspace='/tmp', tarball_path=None, loglevel='ERROR', clean_ws=True):
+def build(reponame, repopath,
+    workspace='/tmp', tarball_path=None, loglevel='ERROR',
+    clean_ws=True, master_branches=['master']):
     """Moves sources to workspace inside of temporary directory. \
     Some operations over sources cant be proceed concurent(for exemple in pytest with xdist \
     plugin) that why each thread need is own tmp dir with sources. \
@@ -97,7 +99,7 @@ def build(reponame, repopath, workspace='/tmp', tarball_path=None, loglevel='ERR
     tarpath = _prepare_result_dir(workspace, tarball_path)
     spec_processing(spec, work_dir_paths, workspace)
 
-    out = _pack(reponame, work_dir_paths, tarpath, spec)
+    out = _pack(reponame, work_dir_paths, tarpath, spec, master_branches=master_branches)
     if clean_ws:
         _clean_ws(ws_tepm_dir)
 

--- a/adcm_client/packer/bundle_build.py
+++ b/adcm_client/packer/bundle_build.py
@@ -32,15 +32,19 @@ def _prepare_ws(reponame, workspace, src_path, spec: SpecFile):
 
 
 def _prepare_result_dir(workspace, tarball_path):
-    tarpath = tarball_path if tarball_path else workspace
-    os.makedirs(tarpath, exist_ok=True)
-    return tarpath
+    if tarball_path:
+        os.makedirs(tarball_path, exist_ok=True)
+        return tarball_path
+    else:
+        return workspace
+    
 
 
-def _pack(reponame, repopaths, tarpath, spec: SpecFile, **kwargs):
+def _pack(reponame, repopaths, tarpaths, spec: SpecFile, **kwargs):
     tarballs = {}
     for edition in spec.data['editions']:
         name = edition.get('name')
+        tarpath = tarpaths[name] if isinstance(tarpaths, dict) else tarpaths
         repopath = repopaths[name]
         tar_except = edition.get('exclude', [])
 
@@ -62,12 +66,15 @@ def _pack(reponame, repopaths, tarpath, spec: SpecFile, **kwargs):
 
 
 def _clean_ws(path):
-    remove_tree(path)
-
+    if isinstance(path, dict):
+        for i in path.values():
+            remove_tree(i)
+    else:
+        remove_tree(path)
 
 def build(reponame, repopath,
     workspace='/tmp', tarball_path=None, loglevel='ERROR',
-    clean_ws=True, master_branches=['master']):
+    clean_ws=True, master_branches=['master'], autotest=False):
     """Moves sources to workspace inside of temporary directory. \
     Some operations over sources cant be proceed concurent(for exemple in pytest with xdist \
     plugin) that why each thread need is own tmp dir with sources. \
@@ -96,7 +103,10 @@ def build(reponame, repopath,
     spec = SpecFile(os.path.join(repopath, 'spec.yaml'))
     spec.normalize_spec()
     ws_tepm_dir, work_dir_paths = _prepare_ws(reponame, workspace, repopath, spec)
-    tarpath = _prepare_result_dir(workspace, tarball_path)
+    if autotest:
+        tarpath = _prepare_result_dir(work_dir_paths, tarball_path)
+    else:
+        tarpath = _prepare_result_dir(workspace, tarball_path)
     spec_processing(spec, work_dir_paths, workspace)
 
     out = _pack(reponame, work_dir_paths, tarpath, spec, master_branches=master_branches)

--- a/adcm_client/packer/naming_rules.py
+++ b/adcm_client/packer/naming_rules.py
@@ -18,7 +18,7 @@ class RestrictedSymbol(Exception):
         self.errors = errors
 
 
-def add_build_id(path, reponame, edition, master_brances: list):
+def add_build_id(path, reponame, edition, master_branches: list):
     def write_version(file, old_version, new_version):
         with open(file, 'r+') as config:
             data = config.read()
@@ -41,7 +41,7 @@ def add_build_id(path, reponame, edition, master_brances: list):
         except IndexError:
             branch = git.rev_parse('--abbrev-ref', 'HEAD')
 
-    if branch in master_brances:
+    if branch in master_branches:
         branch = '-1'
     elif git.describe('--all').split('/')[1] == 'pr':
         branch = '-rc' + branch + '.' + strftime("%Y%m%d%H%M%S", gmtime())

--- a/adcm_client/packer/naming_rules.py
+++ b/adcm_client/packer/naming_rules.py
@@ -18,7 +18,7 @@ class RestrictedSymbol(Exception):
         self.errors = errors
 
 
-def add_build_id(path, reponame, edition):
+def add_build_id(path, reponame, edition, master_brances: list):
     def write_version(file, old_version, new_version):
         with open(file, 'r+') as config:
             data = config.read()
@@ -41,12 +41,12 @@ def add_build_id(path, reponame, edition):
         except IndexError:
             branch = git.rev_parse('--abbrev-ref', 'HEAD')
 
-    if branch == 'master':
+    if branch in master_brances:
         branch = '-1'
     elif git.describe('--all').split('/')[1] == 'pr':
         branch = '-rc' + branch + '.' + strftime("%Y%m%d%H%M%S", gmtime())
     else:
-        branch = '-' + branch
+        branch = '-' + branch.replace("-", "_")
 
     if version is None:
         raise NoVersionFound('No version detected').with_traceback(sys.exc_info()[2])

--- a/bin/adcm_sdk_pack
+++ b/bin/adcm_sdk_pack
@@ -24,6 +24,9 @@ if __name__ == "__main__":
                         default='/tmp')
     parser.add_argument('-c', '--dont-clean-ws', help='remove temporary files from ws',
                         action="store_false")
+    parser.add_argument('-m', '--master-branches', nargs='+', help='non default master branches', default=['master'])
     args = parser.parse_args()
-
-    build(args.name, args.path, args.workspace, args.tarpath, 'INFO', args.dont_clean_ws)
+    build(args.name, args.path,
+        workspace=args.workspace, tarball_path=args.tarpath,
+        loglevel='INFO', clean_ws=args.dont_clean_ws,
+        master_branches=args.master_branches)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ import setuptools
 
 setuptools.setup(
     name="adcm_client",
-    version="2019.10.31.17",
+    version="2019.11.12.12",
     author="Anton Chevychalov",
     author_email="cab@arenadata.io",
     description="ArenaData Cluster Manager Client",


### PR DESCRIPTION
sometime projects default branch is not master. This case may be detect with git.
But more offen in this cases there are usually more then 1 master branch( like ADB repository ).
That why added -m or --master-branches argument for adcm_sdk pack.
By default it has value [master].