### PR TITLE
Added facility to differ release and non-release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,5 @@ dmypy.json
 
 # venv
 /env/
+
+/adcm_client/packer/test_bundle_repo

--- a/adcm_client/packer/bundle_build.py
+++ b/adcm_client/packer/bundle_build.py
@@ -71,7 +71,7 @@ def _clean_ws(path):
 def build(reponame=None, repopath=None, workspace='/tmp',  # pylint: disable=R0913
           tarball_path=None, loglevel='ERROR',
           clean_ws=True, master_branches=None,
-          github_token=None, **args):
+          release_version=False, **args):
     """Moves sources to workspace inside of temporary directory. \
     Some operations over sources cant be proceed concurent(for exemple in pytest with xdist \
     plugin) that why each thread need is own tmp dir with sources. \
@@ -112,7 +112,7 @@ def build(reponame=None, repopath=None, workspace='/tmp',  # pylint: disable=R09
     ws_tepm_dir, work_dir_paths = _prepare_ws(reponame, workspace, repopath, spec)
 
     tarpath = _prepare_result_dir(workspace, tarball_path)
-    spec_processing(spec, work_dir_paths, workspace, master_branches, github_token)
+    spec_processing(spec, work_dir_paths, workspace, release_version)
 
     out = dict(
         _pack(

--- a/adcm_client/packer/bundle_build.py
+++ b/adcm_client/packer/bundle_build.py
@@ -27,7 +27,7 @@ def _prepare_ws(reponame, workspace, src_path, spec: SpecFile):
     tmpdir = mkdtemp(prefix=reponame + '_', dir=workspace)
     for edition in spec.data['editions']:
         edition_dirs.update({edition['name']: os.path.join(tmpdir, str(edition['name']))})
-        copy_tree(src_path, edition_dirs[edition['name']])
+        copy_tree(src_path, edition_dirs[edition['name']], preserve_symlinks=True)
     return tmpdir, edition_dirs
 
 
@@ -70,7 +70,8 @@ def _clean_ws(path):
 
 def build(reponame=None, repopath=None, workspace='/tmp',  # pylint: disable=R0913
           tarball_path=None, loglevel='ERROR',
-          clean_ws=True, master_branches=None, **args):
+          clean_ws=True, master_branches=None,
+          github_token=None, **args):
     """Moves sources to workspace inside of temporary directory. \
     Some operations over sources cant be proceed concurent(for exemple in pytest with xdist \
     plugin) that why each thread need is own tmp dir with sources. \
@@ -111,7 +112,7 @@ def build(reponame=None, repopath=None, workspace='/tmp',  # pylint: disable=R09
     ws_tepm_dir, work_dir_paths = _prepare_ws(reponame, workspace, repopath, spec)
 
     tarpath = _prepare_result_dir(workspace, tarball_path)
-    spec_processing(spec, work_dir_paths, workspace)
+    spec_processing(spec, work_dir_paths, workspace, master_branches, github_token)
 
     out = dict(
         _pack(

--- a/adcm_client/packer/naming_rules.py
+++ b/adcm_client/packer/naming_rules.py
@@ -99,8 +99,6 @@ def check_version(version):
     :raises TypeError: version is not string
     :raises RestrictedSymbol: version contains dash
     """
-    if version is None:
-        raise NoVersionFound('No version detected').with_traceback(sys.exc_info()[2])
     if not isinstance(version, str):
         raise TypeError('Bundle version must be string').with_traceback(sys.exc_info()[2])
     if '-' in version:
@@ -152,10 +150,14 @@ def add_build_id(path, reponame, edition, master_branches: list):
     bundle = ConfigData(catalog=path)
     version = bundle.get_data('version', 'catalog', explict_raw=True)
 
-    check_version(version)
+    if version is None:
+        raise NoVersionFound('No version detected').with_traceback(sys.exc_info()[2])
 
     git_data = get_git_data(path)
-    build_id = resolve_build_id(git_data, master_branches)
-    write_version(bundle.file, version, version + build_id)
+    build_id = ''
+    if git_data:
+        check_version(version)
+        build_id = resolve_build_id(git_data, master_branches)
+        write_version(bundle.file, version, version + build_id)
 
     return str(reponame) + '_v' + str(version) + build_id + '_' + edition + '.tgz'

--- a/adcm_client/packer/naming_rules.py
+++ b/adcm_client/packer/naming_rules.py
@@ -9,8 +9,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import sys
 import io
+import sys
 from time import gmtime, strftime
 
 from git import Repo
@@ -52,6 +52,85 @@ class ReadFileWrapper:
         return end_pos
 
 
+def get_git_data(path):
+    """
+        Return git repo data.
+        In case of branch retun {branch: _name_}
+        In case of pr return {pull_request: _number_}
+        If not detect git repo return None
+    """
+    try:
+        repo = Repo(path)
+    except InvalidGitRepositoryError:
+        return None
+
+    describe = repo.git.describe('--all')
+    describe_list = describe.split('/')
+    reponame = repo.remotes.origin.url.split('/')[-1].split('.git')[0]
+    repoowner = repo.remotes.origin.url.split('/')[-2].split('.com:')[-1]
+
+    data = {'reponame': reponame, 'repoowner': repoowner}
+    # pull request case
+    # it works basically on ci with
+    # clean git init and fetch remote with +refs/pull/*:refs/origin/pr/*
+    # in onther cases with high chance it wont detect pr
+    if describe_list[1] == 'pr' and len(describe_list) > 2:
+        data.update({'pull_request': describe_list[2]})
+        return data
+    # tags case
+    if describe_list[0] == 'tags':
+        branch = next(filter(
+            lambda x: 'origin' in x,
+            repo.git.branch('-a', '--contains', describe).splitlines())).split('/')[2]
+    # all others case
+    else:
+        branch = repo.git.rev_parse('--abbrev-ref', 'HEAD')
+
+    data.update({'branch': branch})
+    return data
+
+
+def check_version(version):
+    """Check version format rules
+
+    :param version: bundle_version
+    :type version: str
+    :raises NoVersionFound: no version is given
+    :raises TypeError: version is not string
+    :raises RestrictedSymbol: version contains dash
+    """
+    if version is None:
+        raise NoVersionFound('No version detected').with_traceback(sys.exc_info()[2])
+    if not isinstance(version, str):
+        raise TypeError('Bundle version must be string').with_traceback(sys.exc_info()[2])
+    if '-' in version:
+        raise RestrictedSymbol('Version contains restricted symbol \
+            "-" in position %s' % version.index('-')).with_traceback(sys.exc_info()[2])
+
+
+def resolve_build_id(git_data, master_branches):
+    """resolves build id according to discovered git data
+
+    :param git_data: discovered git data
+    :type git_data: None or dict
+    :param master_branches: list of master branches
+    :type master_branches: list
+    :return: build id
+    :rtype: str
+    """
+    if git_data:
+        if 'pull_request' in git_data:
+            build_id = '-rc' + git_data['pull_request'] + '.' + strftime("%Y%m%d%H%M%S", gmtime())
+        else:
+            if git_data['branch'] in master_branches:
+                build_id = '-1'
+            else:
+                build_id = '-' + git_data['branch'].replace("-", "_")
+    else:
+        build_id = '-1'
+    return build_id
+
+
 def add_build_id(path, reponame, edition, master_branches: list):
     def write_version(file, old_version, new_version):
         with io.open(file, 'r+') as config:
@@ -73,34 +152,10 @@ def add_build_id(path, reponame, edition, master_branches: list):
     bundle = ConfigData(catalog=path)
     version = bundle.get_data('version', 'catalog', explict_raw=True)
 
-    if version is None:
-        raise NoVersionFound('No version detected').with_traceback(sys.exc_info()[2])
+    check_version(version)
 
-    try:
-        git = Repo(path).git
-        if git.describe('--all').split('/')[0] == 'tags':
-            tag = git.describe('--all')
-            branch = [out.split('/')[2] for out in git.branch('-a', '--contains', tag).splitlines()
-                      if 'origin' in out][0]
-        else:
-            try:
-                branch = git.describe('--all').split('/')[2]
-            except IndexError:
-                branch = git.rev_parse('--abbrev-ref', 'HEAD')
-        if branch in master_branches:
-            branch = '-1'
-        elif git.describe('--all').split('/')[1] == 'pr':
-            branch = '-rc' + branch + '.' + strftime("%Y%m%d%H%M%S", gmtime())
-        else:
-            branch = '-' + branch.replace("-", "_")
-    except InvalidGitRepositoryError:
-        branch = ''
-    else:
-        if not isinstance(version, str):
-            raise TypeError('Bundle version must be string').with_traceback(sys.exc_info()[2])
-        if '-' in version:
-            raise RestrictedSymbol('Version contains restricted symbol \
-                "-" in position %s' % version.index('-')).with_traceback(sys.exc_info()[2])
-        write_version(bundle.file, version, version + branch)
+    git_data = get_git_data(path)
+    build_id = resolve_build_id(git_data, master_branches)
+    write_version(bundle.file, version, version + build_id)
 
-    return str(reponame) + '_v' + str(version) + branch + '_' + edition + '.tgz'
+    return str(reponame) + '_v' + str(version) + build_id + '_' + edition + '.tgz'

--- a/adcm_client/packer/spec.py
+++ b/adcm_client/packer/spec.py
@@ -76,7 +76,7 @@ class SpecFile:
         return tar_except
 
 
-def spec_processing(spec: SpecFile, path, workspace, master_branches, gh_token):
+def spec_processing(spec: SpecFile, path, workspace, release_version):
     for edition in spec.data['editions']:
         if edition.get('preprocessors'):
             for x in edition['preprocessors']:
@@ -87,9 +87,8 @@ def spec_processing(spec: SpecFile, path, workspace, master_branches, gh_token):
                     logging.info(check_output(command, cwd=path[edition['name']]).decode("utf-8"))
                 else:
                     if x['type'] == 'splitter':
-                        params = {'jinja_values': {'edition': edition['name']},
-                                  'master_branches': master_branches,
-                                  'github_token': gh_token}
+                        params = {'jinja_values': {'edition': edition['name'],
+                                                   'release_version': release_version}}
                     else:
                         params = {}
                     get_type_func(x['type'])(path[edition['name']], workspace,

--- a/adcm_client/packer/spec.py
+++ b/adcm_client/packer/spec.py
@@ -76,7 +76,7 @@ class SpecFile:
         return tar_except
 
 
-def spec_processing(spec: SpecFile, path, workspace):
+def spec_processing(spec: SpecFile, path, workspace, master_branches, gh_token):
     for edition in spec.data['editions']:
         if edition.get('preprocessors'):
             for x in edition['preprocessors']:
@@ -86,6 +86,11 @@ def spec_processing(spec: SpecFile, path, workspace):
                         command.extend(x['args'])
                     logging.info(check_output(command, cwd=path[edition['name']]).decode("utf-8"))
                 else:
-                    jinja_values = {'edition': edition['name']}
+                    if x['type'] == 'splitter':
+                        params = {'jinja_values': {'edition': edition['name']},
+                                  'master_branches': master_branches,
+                                  'github_token': gh_token}
+                    else:
+                        params = {}
                     get_type_func(x['type'])(path[edition['name']], workspace,
-                                             edition=jinja_values, **x)
+                                             **params, **x)

--- a/adcm_client/packer/types.py
+++ b/adcm_client/packer/types.py
@@ -23,9 +23,6 @@ from docker.client import DockerClient
 from docker.errors import ImageNotFound
 from docker.models.containers import Container  # pylint: disable=unused-import
 from docker.models.images import Image
-from github import Github
-
-from .naming_rules import get_git_data
 
 
 class NoModulesToInstall(Exception):
@@ -198,37 +195,13 @@ def python_mod_req(source_path, workspace, **kwargs):
             raise NoModulesToInstall('Can`t get python modules list to be inatalled')
 
 
-def is_release(git_data, master_branches, github_token=None):
-    if git_data:
-        if 'branch' in git_data:
-            return git_data['branch'] in master_branches
-        elif 'pull_request' in git_data:
-            if not github_token:
-                raise Exception('For packing pull request case and splitter usage '
-                                'github token option must be defined. Use -g option')
-            github = Github(github_token)
-            repo = github.get_repo(git_data['repoowner'] + '/' + git_data['reponame'])
-            pr = repo.get_pull(int(git_data['pull_request']))
-            return pr.base.ref in master_branches
-        else:
-            raise NotImplementedError('This code must not arrive here')
-    return True
-
-
 def splitter(*args, **kwargs):
     env = jinja2.Environment(loader=jinja2.FileSystemLoader(args[0]),
                              undefined=jinja2.StrictUndefined)
-    git_data = get_git_data(args[0])
-    env_vars = kwargs['jinja_values']
-    env_vars.update(
-        {'release_version': is_release(git_data,
-                                       kwargs['master_branches'],
-                                       kwargs['github_token'])}
-    )
     for file in kwargs['files']:
         tmpl = env.get_template(file)
         with codecs.open(os.path.join(args[0], (os.path.splitext(file)[0])), 'w', 'utf-8') as f:
-            f.write(tmpl.render(env_vars))
+            f.write(tmpl.render(**kwargs['jinja_values']))
 
 
 def get_type_func(tpe):

--- a/bin/adcm_sdk_pack
+++ b/bin/adcm_sdk_pack
@@ -27,9 +27,8 @@ if __name__ == "__main__":
     parser.add_argument('-m', '--master-branches', nargs='+',
                         help='non default master branches', default=['master'])
     parser.add_argument('-v', '--verbose', action="store_true", help='show info', required=False)
-    parser.add_argument('-g', '--github-token', type=str,
-                        help='requires for spec splitter when path contains git directory',
-                        required=False, default=None)
+    parser.add_argument('-r', '--release', action="store_true",
+                        help='set splitter release flag to true', default=None)
     args = parser.parse_args()
 
     loglevel = 'INFO' if args.verbose else 'ERROR'
@@ -37,7 +36,7 @@ if __name__ == "__main__":
     tarballs = build(args.name, args.path,
                      workspace=args.workspace, tarball_path=args.tarpath,
                      loglevel=loglevel, clean_ws=args.dont_clean_ws,
-                     master_branches=args.master_branches, github_token=args.github_token)
+                     master_branches=args.master_branches, release_version=args.release)
 
     for edition in tarballs:
         with open(edition, 'wb') as file:

--- a/bin/adcm_sdk_pack
+++ b/bin/adcm_sdk_pack
@@ -27,6 +27,9 @@ if __name__ == "__main__":
     parser.add_argument('-m', '--master-branches', nargs='+',
                         help='non default master branches', default=['master'])
     parser.add_argument('-v', '--verbose', action="store_true", help='show info', required=False)
+    parser.add_argument('-g', '--github-token', type=str,
+                        help='requires for spec splitter when path contains git directory',
+                        required=False, default=None)
     args = parser.parse_args()
 
     loglevel = 'INFO' if args.verbose else 'ERROR'
@@ -34,7 +37,7 @@ if __name__ == "__main__":
     tarballs = build(args.name, args.path,
                      workspace=args.workspace, tarball_path=args.tarpath,
                      loglevel=loglevel, clean_ws=args.dont_clean_ws,
-                     master_branches=args.master_branches)
+                     master_branches=args.master_branches, github_token=args.github_token)
 
     for edition in tarballs:
         with open(edition, 'wb') as file:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ extras = {
 
 setuptools.setup(
     name="adcm_client",
-    version="2020.03.30.18",
+    version="2020.04.16.18",
     author="Anton Chevychalov",
     author_email="cab@arenadata.io",
     description="ArenaData Cluster Manager Client",
@@ -28,7 +28,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         'pyyaml', 'coreapi', 'ipython', 'gitpython', 'docker', 'jinja2',
-        'version_utils'
+        'version_utils', 'PyGithub'
     ],
     tests_require=test_deps,
     extras_require=extras,

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         'pyyaml', 'coreapi', 'ipython', 'gitpython', 'docker', 'jinja2',
-        'version_utils', 'PyGithub'
+        'version_utils'
     ],
     tests_require=test_deps,
     extras_require=extras,

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ extras = {
 
 setuptools.setup(
     name="adcm_client",
-    version="2020.04.20.19",
+    version="2020.04.29.19",
     author="Anton Chevychalov",
     author_email="cab@arenadata.io",
     description="ArenaData Cluster Manager Client",


### PR DESCRIPTION
Added boolean variable "release_version" to preprocessor splitter jinja environment.
If git repository is not detected its true, same for master branches and pr to master branches.
In case of pr adcm_sdk_pack startup option should provide github token with read access to repository.
"-g" and "--github-token" statup option implemented.