### PR TITLE
Fix 413 Request Entity Too Large

### DIFF
--- a/adcm_client/util/stream.py
+++ b/adcm_client/util/stream.py
@@ -9,7 +9,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import gzip
 import io
 import os
 
@@ -22,10 +21,7 @@ def file(path, **args):
         return list(build(repopath=path, **args).values())
     else:
         stream = io.BytesIO()
-        try:
-            stream.write(gzip.open(path, 'rb').read())
-        except OSError:
-            stream.write(io.open(path, 'rb').read())
+        stream.write(io.open(path, 'rb').read())
         stream.seek(0)
         return [stream]
 


### PR DESCRIPTION
Adcm nginx client_max_body_size = 100m. So bundles larger then 100m cant be
uploaded. Function "file" is used in client "upload_from_fs" method to
return a list of io.BytesIO objects. Use cases for upload_from_fs:
  - upload dir.
  - upload tar.gz

In first case we run adcm_sdk_pack main build func.
In second case we just need to write tar.gz file to BytesIO object.

Used gzip.open method to read tar.gz file decopress archive and
uploaded object became much larger that in compress state. So in case
when size exceeds 100m we get 413 error from nginx. Solution is to
read file with io.open method.
Why previous realization used gzip.open and io.open as failover is unclear.