### PR TITLE
Fix bundles naming

### DIFF
--- a/adcm_client/packer/naming_rules.py
+++ b/adcm_client/packer/naming_rules.py
@@ -85,7 +85,7 @@ def resolve_build_id(git_data, master_branches, timestamp):
             if git_data['branch'] in master_branches:
                 build_id = '-1'
             else:
-                build_id = '-' + git_data['branch'].replace("-", "_")
+                build_id = '-' + git_data['branch'].replace("-", "_").replace("/", "_")
     else:
         build_id = '-1'
     return build_id

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ test_deps = [
     'pytest',
 ]
 setup_deps = [
-    'ad_ci_tools==0.1.0',
+    'ad_ci_tools==0.1.5',
     'pytz',
     'setuptools',
     'wheel'
@@ -54,7 +54,7 @@ setuptools.setup(
     url="https://github.com/arenadata/adcm",
     packages=setuptools.find_packages(),
     install_requires=[
-        'pyyaml', 'coreapi', 'ipython', 'ad_ci_tools==0.1.0',
+        'pyyaml', 'coreapi', 'ipython', 'ad_ci_tools==0.1.5',
         'docker', 'jinja2', 'version_utils'
     ],
     tests_require=test_deps,


### PR DESCRIPTION
For branches like feature/TASK-ID/SUBTASK-ID fixed wrong branch
name detection - wrong split.
All "/" symbols replaced with "_" in bundles names and versions.