### PR TITLE
Add reset method for ADCMClient object

### DIFF
--- a/adcm_client/objects.py
+++ b/adcm_client/objects.py
@@ -1069,6 +1069,10 @@ class ADCMClient:
         self._api.fetch()
         self.adcm_version = self._api.adcm_version
 
+    def reset(self, api=None, url=None, user=None, password=None):
+        """Re-init object. Useful in tests"""
+        self.__init__(api=api, url=url, user=user, password=password)
+
     def _check_min_version(self):
         if rpm.compare_versions(self._MIN_VERSION, self._api.adcm_version) > -1:
             raise ADCMApiError(


### PR DESCRIPTION
This feature id useful it tests when we do ADCM upgrade bu runnig new ADCM container. In this case we want to have the same ADCMClient object but now related to the new ADCM.