### PR TITLE
Add possibility to use activatable group for run object actions

### DIFF
--- a/src/adcm_client/objects.py
+++ b/src/adcm_client/objects.py
@@ -1038,6 +1038,11 @@ class Action(BaseAPIObject):
 
                 if 'config_diff' in args:
                     config_diff = args.pop('config_diff')
+                    if 'config' in config_diff and 'attr' in config_diff:
+                        args['attr'] = {}
+                        for item in self.config["attr"]:
+                            args['attr'][item] = config_diff['attr'].get(item) or self.config['attr'][item]
+                        config_diff = config_diff['config']
                     for item in self.config['config']:
                         if item['type'] == 'group':
                             continue

--- a/src/adcm_client/objects.py
+++ b/src/adcm_client/objects.py
@@ -1024,7 +1024,7 @@ class Action(BaseAPIObject):
         """Return 'TaskList' object"""
         return self._child_obj(TaskList, **args)
 
-    def run(self, **args) -> "Task":
+    def run(self, **args) -> "Task":  # pylint: disable=too-many-branches
         with allure_step(f"Run action {self.name}"):
 
             if 'hc' in args:
@@ -1041,7 +1041,9 @@ class Action(BaseAPIObject):
                     if 'config' in config_diff and 'attr' in config_diff:
                         args['attr'] = {}
                         for item in self.config["attr"]:
-                            args['attr'][item] = config_diff['attr'].get(item) or self.config['attr'][item]
+                            args['attr'][item] = (
+                                config_diff['attr'].get(item) or self.config['attr'][item]
+                            )
                         config_diff = config_diff['config']
                     for item in self.config['config']:
                         if item['type'] == 'group':


### PR DESCRIPTION
In previous versions, we can just pass action config if action has only one activatable group. It will be  failed if there are more than one activatable groups

Motivation - https://allure-ee.adsw.io/launch/19096/tree/8745648?treeId=17