### PR TITLE
ADCM-2915 Add ADCM to `TASK_PARENT` to allow working with ADCM actions via client

### DIFF
--- a/src/adcm_client/objects.py
+++ b/src/adcm_client/objects.py
@@ -1533,6 +1533,9 @@ class ADCM(_BaseObject):
         raise NotImplementedError
 
 
+TASK_PARENT['adcm'] = ADCM
+
+
 class Concern(BaseAPIObject):
     IDNAME = 'concern_id'
     PATH = ['concern']


### PR DESCRIPTION
Quick fix, as an alternative I may suggest moving ADCM declaration before the `TASK_PARENT`