### PR TITLE
Ability to change current user password

### DIFF
--- a/src/adcm_client/objects.py
+++ b/src/adcm_client/objects.py
@@ -1282,7 +1282,7 @@ class Action(BaseAPIObject):
                         args['attr'] = {}
                         for item in self.config["attr"]:
                             args['attr'][item] = (
-                                    config_diff['attr'].get(item) or self.config['attr'][item]
+                                config_diff['attr'].get(item) or self.config['attr'][item]
                             )
                         config_diff = config_diff['config']
                     for item in self.config['config']:
@@ -1937,13 +1937,13 @@ class PolicyList(BaseAPIListObject):
 
 @allure_step('Create policy {name}')
 def new_policy(
-        api: ADCMApiWrapper,
-        name: str,
-        role: Role,
-        user: UserList = None,
-        group: GroupList = None,
-        objects: List[Union[Cluster, Service, Component, Provider, Host]] = None,
-        description: str = '',
+    api: ADCMApiWrapper,
+    name: str,
+    role: Role,
+    user: UserList = None,
+    group: GroupList = None,
+    objects: List[Union[Cluster, Service, Component, Provider, Host]] = None,
+    description: str = '',
 ):
     kwargs = {
         "name": name,
@@ -2241,13 +2241,13 @@ class ADCMClient:
         return RoleList(self._api, paging=paging, **kwargs)
 
     def _policy_create_old(
-            self,
-            name: str,
-            role: Role,
-            user: Union[UserList, List[User]],
-            group: Union[GroupList, List[Group]] = None,
-            objects: List[Union[Cluster, Service, Component, Provider, Host]] = None,
-            description: str = '',
+        self,
+        name: str,
+        role: Role,
+        user: Union[UserList, List[User]],
+        group: Union[GroupList, List[Group]] = None,
+        objects: List[Union[Cluster, Service, Component, Provider, Host]] = None,
+        description: str = '',
     ) -> "Policy":
         """Create `Policy` object"""
         return new_policy(
@@ -2265,12 +2265,12 @@ class ADCMClient:
         _policy_create_old, "2023.06.15.00"
     )  # TODO update version after fix
     def policy_create(
-            self,
-            name: str,
-            role: Role,
-            group: Union[GroupList, List[Group]],
-            objects: List[Union[Cluster, Service, Component, Provider, Host]] = None,
-            description: str = '',
+        self,
+        name: str,
+        role: Role,
+        group: Union[GroupList, List[Group]],
+        objects: List[Union[Cluster, Service, Component, Provider, Host]] = None,
+        description: str = '',
     ) -> "Policy":
         """Create `Policy` object"""
         return new_policy(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -395,3 +395,19 @@ def test_maintenance_mode_set(sdk_client_fs: ADCMClient):
         assert component.maintenance_mode == "ON"
         component.maintenance_mode_set("OFF")
         assert component.maintenance_mode == "OFF"
+
+
+def test_self_password_change(sdk_client_fs: ADCMClient, adcm_api_credentials: dict):
+    test_password = "test_password"
+    with allure.step("Change self user password"):
+        user = sdk_client_fs.user(username=adcm_api_credentials["user"])
+        user.change_password(test_password)
+    with allure.step("Check that we still have access with the same ADCMClient"):
+        user = sdk_client_fs.user(username=adcm_api_credentials["user"])
+        assert user.username == adcm_api_credentials["user"]
+    with allure.step("Check access with modified password"):
+        custom_adcm_client = ADCMClient(
+            url=sdk_client_fs.url, user=adcm_api_credentials["user"], password=test_password
+        )
+        user = custom_adcm_client.user(username=adcm_api_credentials["user"])
+        assert user.username == adcm_api_credentials["user"]


### PR DESCRIPTION
We should auth again if we change password for the current user.
We cannot use self.reread() without re-auth with new password.